### PR TITLE
fix: fixed 'DefaultCredential' CodeQL issues.

### DIFF
--- a/src/backend/agents/image_content_agent.py
+++ b/src/backend/agents/image_content_agent.py
@@ -202,7 +202,7 @@ Style: Modern, clean, minimalist. Brand colors: {brand.primary_color}, {brand.se
         # Get credential
         app_env = os.environ.get("APP_ENV", "prod").lower()
         if app_env == "dev":
-            credential = DefaultAzureCredential(require_envvar=True)
+            credential = DefaultAzureCredential()
         else:
             credential = ManagedIdentityCredential(
                 client_id=app_settings.base_settings.azure_client_id
@@ -324,7 +324,7 @@ MANDATORY FINAL CHECKLIST:
         # Get credential
         app_env = os.environ.get("APP_ENV", "prod").lower()
         if app_env == "dev":
-            credential = DefaultAzureCredential(require_envvar=True)
+            credential = DefaultAzureCredential()
         else:
             credential = ManagedIdentityCredential(
                 client_id=app_settings.base_settings.azure_client_id

--- a/src/backend/agents/image_content_agent.py
+++ b/src/backend/agents/image_content_agent.py
@@ -5,6 +5,7 @@ to create marketing images using the image generation model.
 """
 
 import logging
+import os
 
 from openai import AsyncAzureOpenAI
 from azure.identity.aio import DefaultAzureCredential, ManagedIdentityCredential
@@ -199,11 +200,13 @@ Style: Modern, clean, minimalist. Brand colors: {brand.primary_color}, {brand.se
 
     try:
         # Get credential
-        client_id = app_settings.base_settings.azure_client_id
-        if client_id:
-            credential = ManagedIdentityCredential(client_id=client_id)
+        app_env = os.environ.get("APP_ENV", "prod").lower()
+        if app_env == "dev":
+            credential = DefaultAzureCredential(require_envvar=True)
         else:
-            credential = DefaultAzureCredential()
+            credential = ManagedIdentityCredential(
+                client_id=app_settings.base_settings.azure_client_id
+            )
 
         # Get token for Azure OpenAI
         token = await credential.get_token("https://cognitiveservices.azure.com/.default")
@@ -319,11 +322,13 @@ MANDATORY FINAL CHECKLIST:
 
     try:
         # Get credential
-        client_id = app_settings.base_settings.azure_client_id
-        if client_id:
-            credential = ManagedIdentityCredential(client_id=client_id)
+        app_env = os.environ.get("APP_ENV", "prod").lower()
+        if app_env == "dev":
+            credential = DefaultAzureCredential(require_envvar=True)
         else:
-            credential = DefaultAzureCredential()
+            credential = ManagedIdentityCredential(
+                client_id=app_settings.base_settings.azure_client_id
+            )
 
         # Get token for Azure OpenAI
         token = await credential.get_token("https://cognitiveservices.azure.com/.default")

--- a/src/backend/services/blob_service.py
+++ b/src/backend/services/blob_service.py
@@ -34,7 +34,7 @@ class BlobStorageService:
         """Return a credential based on the application environment."""
         app_env = os.environ.get("APP_ENV", "prod").lower()
         if app_env == "dev":
-            return DefaultAzureCredential(require_envvar=True)
+            return DefaultAzureCredential()
         return ManagedIdentityCredential(
             client_id=app_settings.base_settings.azure_client_id
         )

--- a/src/backend/services/blob_service.py
+++ b/src/backend/services/blob_service.py
@@ -9,6 +9,7 @@ Provides async operations for:
 
 import base64
 import logging
+import os
 from typing import Optional, Tuple
 from datetime import datetime, timezone
 
@@ -30,11 +31,13 @@ class BlobStorageService:
         self._generated_images_container: Optional[ContainerClient] = None
 
     async def _get_credential(self):
-        """Get Azure credential for authentication."""
-        client_id = app_settings.base_settings.azure_client_id
-        if client_id:
-            return ManagedIdentityCredential(client_id=client_id)
-        return DefaultAzureCredential()
+        """Return a credential based on the application environment."""
+        app_env = os.environ.get("APP_ENV", "prod").lower()
+        if app_env == "dev":
+            return DefaultAzureCredential(require_envvar=True)
+        return ManagedIdentityCredential(
+            client_id=app_settings.base_settings.azure_client_id
+        )
 
     async def initialize(self) -> None:
         """Initialize Blob Storage client and containers."""

--- a/src/backend/services/cosmos_service.py
+++ b/src/backend/services/cosmos_service.py
@@ -8,6 +8,7 @@ Provides async operations for:
 """
 
 import logging
+import os
 from typing import List, Optional
 from datetime import datetime, timezone
 
@@ -29,11 +30,13 @@ class CosmosDBService:
         self._conversations_container: Optional[ContainerProxy] = None
 
     async def _get_credential(self):
-        """Get Azure credential for authentication."""
-        client_id = app_settings.base_settings.azure_client_id
-        if client_id:
-            return ManagedIdentityCredential(client_id=client_id)
-        return DefaultAzureCredential()
+        """Return a credential based on the application environment."""
+        app_env = os.environ.get("APP_ENV", "prod").lower()
+        if app_env == "dev":
+            return DefaultAzureCredential(require_envvar=True)
+        return ManagedIdentityCredential(
+            client_id=app_settings.base_settings.azure_client_id
+        )
 
     async def initialize(self) -> None:
         """Initialize CosmosDB client and containers."""

--- a/src/backend/services/cosmos_service.py
+++ b/src/backend/services/cosmos_service.py
@@ -33,7 +33,7 @@ class CosmosDBService:
         """Return a credential based on the application environment."""
         app_env = os.environ.get("APP_ENV", "prod").lower()
         if app_env == "dev":
-            return DefaultAzureCredential(require_envvar=True)
+            return DefaultAzureCredential()
         return ManagedIdentityCredential(
             client_id=app_settings.base_settings.azure_client_id
         )

--- a/src/tests/agents/test_image_content_agent.py
+++ b/src/tests/agents/test_image_content_agent.py
@@ -134,7 +134,8 @@ async def test_generate_dalle_image_success():
 @pytest.mark.asyncio
 async def test_generate_dalle_image_with_managed_identity():
     """Test DALL-E generation with managed identity credential."""
-    with patch("agents.image_content_agent.app_settings") as mock_settings, \
+    with patch.dict("os.environ", {"APP_ENV": "prod"}), \
+         patch("agents.image_content_agent.app_settings") as mock_settings, \
          patch("agents.image_content_agent.ManagedIdentityCredential") as mock_cred, \
          patch("agents.image_content_agent.AsyncAzureOpenAI") as mock_client:
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -72,6 +72,9 @@ def mock_environment(monkeypatch):
     environment and changes are automatically reverted after the test.
     """
     env_vars = {
+        # Local authentication; managed-identity tests override this to "prod"
+        "APP_ENV": "dev",
+
         # Azure OpenAI (required - _AzureOpenAISettings)
         "AZURE_OPENAI_ENDPOINT": "https://test-openai.openai.azure.com/",
         "AZURE_ENV_OPENAI_API_VERSION": "2024-08-01-preview",

--- a/src/tests/services/test_blob_service.py
+++ b/src/tests/services/test_blob_service.py
@@ -17,7 +17,8 @@ from services.blob_service import BlobStorageService, get_blob_service
 @pytest.mark.asyncio
 async def test_initialize_with_managed_identity():
     """Test initialization with managed identity credential."""
-    with patch("services.blob_service.app_settings") as mock_settings, \
+    with patch.dict("os.environ", {"APP_ENV": "prod"}), \
+         patch("services.blob_service.app_settings") as mock_settings, \
          patch("services.blob_service.ManagedIdentityCredential") as mock_cred, \
          patch("services.blob_service.BlobServiceClient") as mock_client:
 
@@ -44,7 +45,8 @@ async def test_initialize_with_managed_identity():
 @pytest.mark.asyncio
 async def test_initialize_with_default_credential():
     """Test initialization with default Azure credential."""
-    with patch("services.blob_service.app_settings") as mock_settings, \
+    with patch.dict("os.environ", {"APP_ENV": "dev"}), \
+         patch("services.blob_service.app_settings") as mock_settings, \
          patch("services.blob_service.DefaultAzureCredential") as mock_cred, \
          patch("services.blob_service.BlobServiceClient") as mock_client:
 
@@ -64,7 +66,7 @@ async def test_initialize_with_default_credential():
         service = BlobStorageService()
         await service.initialize()
 
-        mock_cred.assert_called_once()
+        mock_cred.assert_called_once_with(require_envvar=True)
 
 
 @pytest.mark.asyncio

--- a/src/tests/services/test_blob_service.py
+++ b/src/tests/services/test_blob_service.py
@@ -66,7 +66,7 @@ async def test_initialize_with_default_credential():
         service = BlobStorageService()
         await service.initialize()
 
-        mock_cred.assert_called_once_with(require_envvar=True)
+        mock_cred.assert_called_once_with()
 
 
 @pytest.mark.asyncio

--- a/src/tests/services/test_cosmos_service.py
+++ b/src/tests/services/test_cosmos_service.py
@@ -39,7 +39,8 @@ def mock_cosmos_service():
 @pytest.mark.asyncio
 async def test_initialize_with_managed_identity():
     """Test initialization with managed identity credential."""
-    with patch("services.cosmos_service.app_settings") as mock_settings, \
+    with patch.dict("os.environ", {"APP_ENV": "prod"}), \
+         patch("services.cosmos_service.app_settings") as mock_settings, \
          patch("services.cosmos_service.ManagedIdentityCredential") as mock_cred, \
          patch("services.cosmos_service.CosmosClient") as mock_client:
 
@@ -70,7 +71,8 @@ async def test_initialize_with_managed_identity():
 @pytest.mark.asyncio
 async def test_initialize_with_default_credential():
     """Test initialization with default Azure credential."""
-    with patch("services.cosmos_service.app_settings") as mock_settings, \
+    with patch.dict("os.environ", {"APP_ENV": "dev"}), \
+         patch("services.cosmos_service.app_settings") as mock_settings, \
          patch("services.cosmos_service.DefaultAzureCredential") as mock_cred, \
          patch("services.cosmos_service.CosmosClient") as mock_client:
 
@@ -93,7 +95,7 @@ async def test_initialize_with_default_credential():
         service = CosmosDBService()
         await service.initialize()
 
-        mock_cred.assert_called_once()
+        mock_cred.assert_called_once_with(require_envvar=True)
 
 
 @pytest.mark.asyncio

--- a/src/tests/services/test_cosmos_service.py
+++ b/src/tests/services/test_cosmos_service.py
@@ -95,7 +95,7 @@ async def test_initialize_with_default_credential():
         service = CosmosDBService()
         await service.initialize()
 
-        mock_cred.assert_called_once_with(require_envvar=True)
+        mock_cred.assert_called_once_with()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
This pull request refactors Azure credential selection logic across the backend and updates related tests to ensure the correct credential is used based on the application environment. Now, when `APP_ENV` is set to "dev", the system uses `DefaultAzureCredential` with stricter requirements; otherwise, it defaults to `ManagedIdentityCredential`. The tests are updated to explicitly set the environment and check for the correct credential instantiation.

**Credential selection logic improvements:**

* Refactored credential selection in `image_content_agent.py`, `blob_service.py`, and `cosmos_service.py` to use `DefaultAzureCredential(require_envvar=True)` in development (`APP_ENV=dev`) and `ManagedIdentityCredential` in production, ensuring consistent and environment-appropriate authentication. [[1]](diffhunk://#diff-b7fc0b2021fce8d2515708077c958751a0eab99c88c5edc00b48881c8ea88a0aR8) [[2]](diffhunk://#diff-b7fc0b2021fce8d2515708077c958751a0eab99c88c5edc00b48881c8ea88a0aL202-R209) [[3]](diffhunk://#diff-b7fc0b2021fce8d2515708077c958751a0eab99c88c5edc00b48881c8ea88a0aL322-R331) [[4]](diffhunk://#diff-832d21d19f4936c251910d50f8fe766c1d2c15fd1f58db062725a528f7996dd7R12) [[5]](diffhunk://#diff-832d21d19f4936c251910d50f8fe766c1d2c15fd1f58db062725a528f7996dd7L33-R40) [[6]](diffhunk://#diff-3f63e39fe196a4f459a731f4cc290646881521fe89178a99444c0637145734b5R11) [[7]](diffhunk://#diff-3f63e39fe196a4f459a731f4cc290646881521fe89178a99444c0637145734b5L32-R39)

**Test updates for environment-based credential selection:**

* Updated tests in `test_image_content_agent.py`, `test_blob_service.py`, and `test_cosmos_service.py` to patch the `APP_ENV` environment variable, ensuring that credential selection logic is properly exercised for both dev and prod environments. [[1]](diffhunk://#diff-5d84fd7f1bfca1a2c5d92e63b0a9911e8a4fd4e13c55c51176c7438d93773e6aL137-R138) [[2]](diffhunk://#diff-3e0395a273e15023024900cb1c0417d0c9788d34b233823bcb71fabfa8874dc3L20-R21) [[3]](diffhunk://#diff-3e0395a273e15023024900cb1c0417d0c9788d34b233823bcb71fabfa8874dc3L47-R49) [[4]](diffhunk://#diff-1b2556e741441fe9720a75447c223bae0ef1be354badb8e7eb40a637d2458266L42-R43) [[5]](diffhunk://#diff-1b2556e741441fe9720a75447c223bae0ef1be354badb8e7eb40a637d2458266L73-R75)
* Adjusted test assertions to verify that `DefaultAzureCredential` is called with `require_envvar=True` in development mode. [[1]](diffhunk://#diff-3e0395a273e15023024900cb1c0417d0c9788d34b233823bcb71fabfa8874dc3L67-R69) [[2]](diffhunk://#diff-1b2556e741441fe9720a75447c223bae0ef1be354badb8e7eb40a637d2458266L96-R98)

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->

- [ ] Yes
- [x] No

<!-- Please prefix your PR title with one of the following:
  * `feat`: A new feature
  * `fix`: A bug fix
  * `docs`: Documentation only changes
  * `style`: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
  * `refactor`: A code change that neither fixes a bug nor adds a feature
  * `perf`: A code change that improves performance
  * `test`: Adding missing tests or correcting existing tests
  * `build`: Changes that affect the build system or external dependencies (example scopes: gulp, broccoli, npm)
  * `ci`: Changes to our CI configuration files and scripts (example scopes: Travis, Circle, BrowserStack, SauceLabs)
  * `chore`: Other changes that don't modify src or test files
  * `revert`: Reverts a previous commit
  * !: A breaking change is indicated with a `!` after the listed prefixes above, e.g. `feat!`, `fix!`, `refactor!`, etc.
-->

